### PR TITLE
replace channel <pubDate> with <lastBuildDate>

### DIFF
--- a/src/Helper/PodcastFeedHelper.php
+++ b/src/Helper/PodcastFeedHelper.php
@@ -38,7 +38,7 @@ class PodcastFeedHelper extends \Feed
         $xml .= '<language>' . $this->language . '</language>';
         $xml .= '<itunes:explicit>' . ((!empty($this->explicit)) ? \StringUtil::specialchars($this->explicit) : 'no') . '</itunes:explicit>';
         $xml .= '<link>' . \StringUtil::specialchars($this->link) . '</link>';
-        $xml .= '<pubDate>' . date('r', $this->published) . '</pubDate>';
+        $xml .= '<lastBuildDate>' . date('r', $this->published) . '</lastBuildDate>';
         $xml .= '<generator>Contao Open Source CMS - News Podcasts</generator>';
         $xml .= '<itunes:owner>';
         $xml .=     '<itunes:name>' . $this->owner . '</itunes:name>';


### PR DESCRIPTION
pubDate sollte auf Channel ebene nicht nötig sein.
Das Erstellungsdatum des gesamten Feeds ist aber ohnehin nicht bekannt.

dahingegen ist <lastBuildDate> zwar auch  nur optional, aber durchaus sinnvoll.

Zudem bezieht sich `$this->published` eh auf die Zeit als die XML Datei das letzte mal geschrieben wurden, und nicht auf die Erstellung des Feed. 
(Könnte von daher eigentlich unbenannt werden von `$this->published` in  `$this->updated` )